### PR TITLE
0.3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ The server serves up information about the contents of a users project. The fron
 
 ## Contributing
 
-Check out the contribution guide [here](https://0hughman0.github.io/Cassini/latest/contributing.html)
+Check out the contribution guide [here](https://0hughman0.github.io/Cassini/latest/contributing/)

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 const jestJupyterLab = require('@jupyterlab/testutils/lib/jest-config');
 
-process.env.TZ = 'UTC';  // ensures test are run in UTC
+process.env.TZ = 'UTC'; // ensures test are run in UTC
 
 const esModules = [
   '@codemirror',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,7 @@
 const jestJupyterLab = require('@jupyterlab/testutils/lib/jest-config');
 
+process.env.TZ = 'UTC';  // ensures test are run in UTC
+
 const esModules = [
   '@codemirror',
   '@jupyter/ydoc',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter_cassini",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Jupyterlab extension for interacting with Cassini projects",
   "keywords": [
     "jupyter",

--- a/src/models.ts
+++ b/src/models.ts
@@ -131,7 +131,7 @@ export class NotebookTierModel implements IDisposable {
       const hltsFile = (this._hltsFile = new Context({
         manager: cassini.contentService,
         factory: new TextModelFactory(),
-        path: options.hltsPath,
+        path: options.hltsPath
       }));
 
       hltsFile.model.contentChanged.connect(() => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -131,7 +131,7 @@ export class NotebookTierModel implements IDisposable {
       const hltsFile = (this._hltsFile = new Context({
         manager: cassini.contentService,
         factory: new TextModelFactory(),
-        path: options.hltsPath as string
+        path: options.hltsPath,
       }));
 
       hltsFile.model.contentChanged.connect(() => {
@@ -314,13 +314,13 @@ export class NotebookTierModel implements IDisposable {
   }
 
   /**
-   * Writes the current state of the metaFile and hltsFile models to the disk.
+   * Writes the current state of the metaFile to the disk.
    *
    * If another program has made changes to these docs in the mean-time e.g. a user is manually changing tier.meta in their python-side code
    * Jupyter may complain, creating a big window about the conflict... this is useful!
    */
   save(): Promise<void> {
-    return Promise.all([this.metaFile?.save(), this.hltsFile?.save()]).then();
+    return Promise.all([this.metaFile.save()]).then();
   }
 
   /**

--- a/src/tests/models.spec.ts
+++ b/src/tests/models.spec.ts
@@ -237,6 +237,25 @@ describe('TierModel', () => {
       expect(tier.description).toBe('load from file');
       expect(tier.dirty).toBe(false);
     });
+
+    test("save doesn't save hlts", async () => {
+      expect(WP1_INFO.hltsPath).toBeDefined();
+
+      const tier = new NotebookTierModel(WP1_INFO);
+      await tier.ready;
+
+      expect(tier.hltsFile).not.toBeFalsy();
+
+      if ( tier.hltsFile ) {
+        const hltsSentinal = tier.hltsFile.save = jest.fn();
+        const metaSentinal = tier.metaFile.save = jest.fn();
+
+        await tier.save();
+
+        expect(metaSentinal).toBeCalled();
+        expect(hltsSentinal).not.toBeCalled();
+      }
+    })
   });
 });
 

--- a/src/tests/models.spec.ts
+++ b/src/tests/models.spec.ts
@@ -246,16 +246,16 @@ describe('TierModel', () => {
 
       expect(tier.hltsFile).not.toBeFalsy();
 
-      if ( tier.hltsFile ) {
-        const hltsSentinal = tier.hltsFile.save = jest.fn();
-        const metaSentinal = tier.metaFile.save = jest.fn();
+      if (tier.hltsFile) {
+        const hltsSentinal = (tier.hltsFile.save = jest.fn());
+        const metaSentinal = (tier.metaFile.save = jest.fn());
 
         await tier.save();
 
         expect(metaSentinal).toBeCalled();
         expect(hltsSentinal).not.toBeCalled();
       }
-    })
+    });
   });
 });
 


### PR DESCRIPTION
Makes model.save not save the hlts, this stops a problem where if a user updates hlts after it's been loaded by the UI, when saving, this could overwrite changes made by the user, including making a confusing popup about saving or reverting!